### PR TITLE
fix prepositions in player game history

### DIFF
--- a/scoreboard/templates/scoreboard/players/games_for_player.html
+++ b/scoreboard/templates/scoreboard/players/games_for_player.html
@@ -15,13 +15,13 @@
                     <td class="py-2 px-5">
                         {% if player_score.result_of_game.winner == player_score.player %}
                             won from <a class="underline text-sky-600" href="{% url 'player' current_league.slug player_score.result_of_game.loser.name %}">
-                                {{ player_score.result_of_game.loser.name }}</a> 
-                            with {{ player_score.result_of_game.winner_points }}-{{ player_score.result_of_game.loser_points }} 
+                                {{ player_score.result_of_game.loser.name }}</a>
+                            by {{ player_score.result_of_game.winner_points }}-{{ player_score.result_of_game.loser_points }} 
                         {% endif %}
                         {% if player_score.result_of_game.loser == player_score.player %}
-                            lost from <a class="underline text-sky-600" href="{% url 'player' current_league.slug player_score.result_of_game.winner.name %}">
-                                {{ player_score.result_of_game.winner.name }}</a> 
-                            with {{ player_score.result_of_game.winner_points }}-{{ player_score.result_of_game.loser_points }} 
+                            lost to <a class="underline text-sky-600" href="{% url 'player' current_league.slug player_score.result_of_game.winner.name %}">
+                                {{ player_score.result_of_game.winner.name }}</a>
+                            by {{ player_score.result_of_game.winner_points }}-{{ player_score.result_of_game.loser_points }} 
                         {% endif %}
                     </td>
                     <td class="py-2 px-5">{{ player_score.rating }}</td>


### PR DESCRIPTION
Replace "with" with "by" for score display, and "lost from" with "lost to" for clearer natural language in the player games overview.