### PR TITLE
Factor game score into Elo rating updates

### DIFF
--- a/scoreboard/elo.py
+++ b/scoreboard/elo.py
@@ -1,7 +1,13 @@
 from .models import Player, Game, Rating
 
 
-def compute_elo(winner_elo: int, loser_elo: int, K: int = 32) -> tuple[int, int]:
+def compute_elo(
+    winner_elo: int,
+    loser_elo: int,
+    K: int = 32,
+    winner_points: int | None = None,
+    loser_points: int | None = None,
+) -> tuple[int, int]:
     Q_winner = pow(10, winner_elo / 400)
     Q_loser = pow(10, loser_elo / 400)
     Q_total = Q_winner + Q_loser
@@ -9,17 +15,36 @@ def compute_elo(winner_elo: int, loser_elo: int, K: int = 32) -> tuple[int, int]
     E_winner = Q_winner / Q_total
     E_loser = Q_loser / Q_total
 
-    new_winner = winner_elo + round(K * (1.0 - E_winner))
-    new_loser = loser_elo + round(K * (0.0 - E_loser))
+    # When scores are provided, use the points ratio as the actual outcome score
+    # rather than a binary 1/0. A 11-0 win gives S≈1.0; an 11-10 win gives S≈0.52.
+    # The two scores always sum to 1, so ratings remain zero-sum.
+    if winner_points is not None and loser_points is not None:
+        total_points = winner_points + loser_points
+        S_winner = winner_points / total_points
+        S_loser = loser_points / total_points
+    else:
+        S_winner = 1.0
+        S_loser = 0.0
+
+    new_winner = winner_elo + round(K * (S_winner - E_winner))
+    new_loser = loser_elo + round(K * (S_loser - E_loser))
 
     return new_winner, new_loser
 
 
 class EloRating:
 
-    def __init__(self, winner: Player, loser: Player):
+    def __init__(
+        self,
+        winner: Player,
+        loser: Player,
+        winner_points: int | None = None,
+        loser_points: int | None = None,
+    ):
         self.winner: Player = winner
         self.loser: Player = loser
+        self.winner_points: int | None = winner_points
+        self.loser_points: int | None = loser_points
         self.new_winner_rating: None | int = None
         self.new_loser_rating: None | int = None
         self.K = 32
@@ -28,7 +53,11 @@ class EloRating:
 
     def compute_new_scores(self):
         self.new_winner_rating, self.new_loser_rating = compute_elo(
-            self.winner.current_elo, self.loser.current_elo, self.K
+            self.winner.current_elo,
+            self.loser.current_elo,
+            self.K,
+            self.winner_points,
+            self.loser_points,
         )
 
     def commit_scores(self, game: Game):

--- a/scoreboard/tests.py
+++ b/scoreboard/tests.py
@@ -44,6 +44,31 @@ class TestComputeElo(TestCase):
         self.assertIsInstance(new_winner, int)
         self.assertIsInstance(new_loser, int)
 
+    def test_dominant_win_gains_more_than_narrow_win(self):
+        # 11-0 win should gain more than an 11-10 win, all else equal
+        dominant_winner, _ = compute_elo(1000, 1000, winner_points=11, loser_points=0)
+        narrow_winner, _ = compute_elo(1000, 1000, winner_points=11, loser_points=10)
+        self.assertGreater(dominant_winner, narrow_winner)
+
+    def test_narrow_win_loser_loses_fewer_points_than_dominant_loss(self):
+        _, dominant_loser = compute_elo(1000, 1000, winner_points=11, loser_points=0)
+        _, narrow_loser = compute_elo(1000, 1000, winner_points=11, loser_points=10)
+        self.assertGreater(narrow_loser, dominant_loser)
+
+    def test_score_based_ratings_are_zero_sum(self):
+        # Total rating points must be conserved
+        new_winner, new_loser = compute_elo(1000, 1200, winner_points=11, loser_points=7)
+        self.assertEqual(new_winner + new_loser, 1000 + 1200)
+
+    def test_score_based_returns_integers(self):
+        new_winner, new_loser = compute_elo(1000, 1000, winner_points=11, loser_points=5)
+        self.assertIsInstance(new_winner, int)
+        self.assertIsInstance(new_loser, int)
+
+    def test_no_scores_matches_legacy_behaviour(self):
+        # Omitting points should give the same result as before
+        self.assertEqual(compute_elo(1000, 1000), compute_elo(1000, 1000, winner_points=None, loser_points=None))
+
 
 class TestPages(TestCase):
 

--- a/scoreboard/views/games/views.py
+++ b/scoreboard/views/games/views.py
@@ -127,7 +127,7 @@ def submit_new_game(request: HttpRequest, league: str) -> HttpResponse:
     
     winner_obj = Player.objects.get(pk=winner_id)
     loser_obj = Player.objects.get(pk=loser_id)
-    elo_rating = EloRating(winner=winner_obj, loser=loser_obj)
+    elo_rating = EloRating(winner=winner_obj, loser=loser_obj, winner_points=winner_points, loser_points=loser_points)
 
     new_game = Game(
         league=league_obj,


### PR DESCRIPTION
Replace the binary win/loss outcome (S=1 or S=0) with a points ratio:
  S_winner = winner_points / (winner_points + loser_points)

This rewards dominant wins more than narrow ones while keeping ratings zero-sum. Passing no points falls back to the original behaviour.